### PR TITLE
Do not spawn a new process for sending data to coveralls

### DIFF
--- a/tasks/coverallsTask.js
+++ b/tasks/coverallsTask.js
@@ -35,25 +35,17 @@ module.exports = function(grunt) {
     function submitToCoveralls(fileName, callback) {
         grunt.verbose.writeln("Submitting file to coveralls.io: " + fileName);
 
-        var child_process = require('child_process');
-        var coverallsRunnerPath = require.resolve('coveralls/bin/coveralls');
-
-        var coveralls = child_process.spawn(process.execPath, [coverallsRunnerPath], {
-            stdio: ['pipe', process.stdout, process.stderr]
-        });
-
-        coveralls.on('exit', function (code) {
-            if (code !== 0) {
-                grunt.verbose.error("Failed to submit " + fileName + " to coveralls");
-                callback(false);
-            } else {
-                grunt.verbose.ok("Successfully submitted " + fileName + " to coveralls");
-                callback(true);
-            }
-        });
-
+        var coveralls = require('coveralls');
         var fs = require('fs');
-        coveralls.stdin.end(fs.readFileSync(fileName, 'utf8'));
+
+        try {
+            coveralls.handleInput(fs.readFileSync(fileName, 'utf8'));
+            grunt.verbose.ok("Successfully submitted " + fileName + " to coveralls");
+            callback(true);
+        } catch (e) {
+            grunt.verbose.error("Failed to submit " + fileName + " to coveralls (" + e + ")");
+            callback(false);
+        }
     }
 
     grunt.registerMultiTask('coveralls', 'Grunt task to load coverage results and submit them to Coveralls.io', Runner);

--- a/test/coveralls_test.js
+++ b/test/coveralls_test.js
@@ -1,10 +1,8 @@
 'use strict';
 
+var coveralls = require('coveralls');
 var grunt = require('grunt');
 var sinon = require('sinon');
-var path = require('path');
-
-var child_process = require('child_process');
 
 function runGruntTask(taskName, callback) {
     var task = grunt.task._taskPlusArgs(taskName);
@@ -17,107 +15,81 @@ function runGruntTask(taskName, callback) {
     }, task.args);
 }
 
-function stubChildProcess() {
-    return {
-        stdin: {
-            end: sinon.stub()
-        },
-        on: sinon.stub()
-    };
-}
-
-var child_process_spawn = child_process.spawn;
+var coveralls_handleInput = coveralls.handleInput;
 
 exports.coveralls = {
     setUp: function (callback) {
-        child_process.spawn = sinon.stub();
+        coveralls.handleInput = sinon.stub();
         callback();
     },
 
     tearDown: function (callback) {
-        child_process.spawn = child_process_spawn;
+        coveralls.handleInput = coveralls_handleInput;
         callback();
     },
 
     submits_file_to_coveralls: function (test) {
-        var procStub = stubChildProcess();
-        var inputStub = procStub.stdin.end;
-        child_process.spawn.returns(procStub);
+        var handleStub = coveralls.handleInput;
 
         runGruntTask('coveralls:basic_test', function (result) {
             test.ok(result, 'Should be successful');
 
-            var pathToCoveralls = path.resolve('./node_modules/coveralls/bin/coveralls.js');
-            test.ok(child_process.spawn.calledWith(sinon.match('node'), [pathToCoveralls]));
-            test.ok(inputStub.calledOnce);
-            test.ok(inputStub.calledWith('lcov.info content'), 'Should send lcov data');
+            test.ok(handleStub.calledOnce);
+            test.equal(handleStub.firstCall.args[0], 'lcov.info content', 'Should send lcov data');
             test.done();
         });
-
-        procStub.on.withArgs('exit').yield(0);
     },
 
     submits_nothing_if_the_file_is_missing: function (test) {
         runGruntTask('coveralls:missing_file_test', function (result) {
             test.ok(!result, 'Should fail');
 
-            test.ok(!child_process.spawn.called);
+            test.ok(!coveralls.handleInput.called);
             test.done();
         });
     },
 
     submits_multiple_files: function (test) {
-        var procStub = stubChildProcess();
-        var inputStub = procStub.stdin.end;
-        child_process.spawn.returns(procStub);
+        var handleStub = coveralls.handleInput;
 
         runGruntTask('coveralls:multiple_files_test', function (result) {
             test.ok(result, 'Should be successful');
 
-            test.ok(inputStub.calledTwice);
-            test.ok(inputStub.calledWith('lcov.info content'), 'Should send first file data');
-            test.ok(inputStub.calledWith('lcov2.info content'), 'Should send second file data');
+            test.ok(handleStub.calledTwice);
+            test.equal(handleStub.firstCall.args[0], 'lcov.info content', 'Should send first file data');
+            test.equal(handleStub.secondCall.args[0], 'lcov2.info content', 'Should send second file data');
             test.done();
         });
-
-        procStub.on.withArgs('exit').yield(0);
     },
 
     submits_present_files_only_if_some_are_missing: function (test) {
-        var procStub = stubChildProcess();
-        var inputStub = procStub.stdin.end;
-        child_process.spawn.returns(procStub);
+        var handleStub = coveralls.handleInput;
 
         runGruntTask('coveralls:some_missing_files_test', function (result) {
             test.ok(result, 'Should be successful');
 
-            test.ok(inputStub.calledOnce);
-            test.ok(inputStub.calledWith('lcov.info content'), 'Should send first file data');
+            test.ok(handleStub.calledOnce);
+            test.equal(handleStub.firstCall.args[0], 'lcov.info content', 'Should send first file data');
             test.done();
         });
-
-        procStub.on.withArgs('exit').yield(0);
     },
 
     fails_if_multiple_files_listed_and_all_files_are_missing: function (test) {
         runGruntTask('coveralls:all_missing_files_test', function (result) {
             test.ok(!result, 'Should fail');
 
-            test.ok(!child_process.spawn.called);
+            test.ok(!coveralls.handleInput.called);
             test.done();
         });
     },
 
     fails_if_any_files_fail_to_upload: function (test) {
-        var procStub = stubChildProcess();
-        child_process.spawn.returns(procStub);
+        var handleStub = coveralls.handleInput;
+        handleStub.throws("Error");
 
         runGruntTask('coveralls:basic_test', function (result) {
             test.ok(!result, 'Should fail');
             test.done();
         });
-
-        // Process returns non-0 status code
-        procStub.on.withArgs('exit').yield(1);
     }
 };


### PR DESCRIPTION
Use the handleInput function of the coveralls module directly to
avoid problems with waiting on child processes. It seams that
Grunt ignores the call to async() and does not wait for finished
tasks before exit. If submitting data to coveralls takes longer
and the task is the last one, it is possible that the process
exits before all data has been submitted.
