### PR TITLE
Warn mode: adds an option to only print a warn instead of an error

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -26,6 +26,12 @@ module.exports = function(grunt) {
             basic_test: {
                 src: 'test/fixtures/lcov.info'
             },
+            basic_test_warn: {
+                src: 'test/fixtures/lcov.info',
+                options: {
+                    warn: true
+                }
+            },
             multiple_files_test: {
                 src: ['test/fixtures/lcov.info', 'test/fixtures/lcov2.info']
             },
@@ -38,7 +44,6 @@ module.exports = function(grunt) {
             all_missing_files_test: {
                 src: ['test/fixtures/nonexistent_lcov1.info', 'test/fixtures/nonexistent_lcov2.info']
             },
-
             grunt_coveralls_real_coverage: {
                 src: 'coverage/lcov.info'
             }

--- a/README.md
+++ b/README.md
@@ -37,7 +37,11 @@ grunt.initConfig({
   coveralls: {
     options: {
       // LCOV coverage file relevant to every target
-      src: 'coverage-results/lcov.info'
+      src: 'coverage-results/lcov.info',
+
+      // if true grunt-coveralls will print only a warning rather than
+      // an error to prevent CI builds from failing. Example: coveralls site is down
+      warn: false
     },
     your_target: {
       // Target-specific LCOV coverage file

--- a/tasks/coverallsTask.js
+++ b/tasks/coverallsTask.js
@@ -2,7 +2,8 @@
 
 module.exports = function(grunt) {
     function Runner() {
-        var done = this.async();
+        var done = this.async(),
+            warn = this.options().warn;
 
         if (this.filesSrc.length === 0) {
             grunt.log.error('No src files could be found for grunt-coveralls');
@@ -19,6 +20,9 @@ module.exports = function(grunt) {
             if (remainingSubmissions === 0) {
                 if (successful) {
                     grunt.log.ok("Successfully submitted coverage results to coveralls");
+                    done(true);
+                } else if (warn) {
+                    grunt.log.warn("WARNING: Failed to submit coverage results to coveralls");
                     done(true);
                 } else {
                     grunt.log.error("Failed to submit coverage results to coveralls");

--- a/test/coveralls_test.js
+++ b/test/coveralls_test.js
@@ -106,5 +106,17 @@ exports.coveralls = {
             test.ok(handleStub.calledOnce);
             test.done();
         });
+    },
+
+    warn_mode_doenst_print_grunt_error: function (test) {
+        coveralls.handleInput.restore();
+        var handleStub = sinon.stub(coveralls, 'handleInput').callsArgWith(1, 'Error');
+
+        runGruntTask('coveralls:basic_test_warn', function (result) {
+            test.ok(result, 'Should not fail when options.warn === true');
+
+            test.ok(handleStub.calledOnce);
+            test.done();
+        });
     }
 };


### PR DESCRIPTION
This option is interesting to not prevent the CI build if coveralls site is down.

It would be probably used on QUnit and other jQuery projects, as you can see on jquery/qunit#507
